### PR TITLE
Cambio en el Pipeline CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,14 +76,15 @@ jobs:
       - name: Ejecutar pruebas con pytest
         run: pytest tests/test_app.py
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Construir y publicar imagen Docker
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/app-medica:latest .
-          docker push ghcr.io/${{ github.repository_owner }}/app-medica:latest
+          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/app-medica:latest
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME


### PR DESCRIPTION
Modifique el pipeline CI/CD para que pueda enviar con un Token la imagen de docker al repositorio de Github. Ya que estaba fallando por no contar con los permisos requeridos y por eso fue necesario crear este Token